### PR TITLE
fix: Trim whitespace from localVersion Gradle property

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/gitflow/extension/VersionExtension.kt
+++ b/src/main/kotlin/com/intershop/gradle/gitflow/extension/VersionExtension.kt
@@ -267,7 +267,7 @@ open class VersionExtension @Inject constructor(project: Project,
 
         val localVersion: Provider<String> = providerFactory.gradleProperty("localVersion")
 
-        versionService.localOnly = localVersion.getOrElse("false").lowercase(Locale.getDefault()) == "true"
+        versionService.localOnly = localVersion.getOrElse("false").lowercase(Locale.getDefault()).trim() == "true"
 
         versionService.isMergeBuild =
             getValueFor("MERGE_BUILD", "mergeBuild", "false")


### PR DESCRIPTION
Trailing whitespace in the Gradle property value of "localVersion" lead to subsequent downstream issues in the local builds for developer(s), therefore this PR fixes the causing problem.