### PR TITLE
feature: Add version support for "support" prefix branches

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/gitflow/utils/GitVersionService.kt
+++ b/src/main/kotlin/com/intershop/gradle/gitflow/utils/GitVersionService.kt
@@ -359,6 +359,9 @@ class GitVersionService @JvmOverloads constructor(
                 branch.startsWith("${releasePrefix}${separator}") -> {
                     rv = versionFromRelease(false)
                 }
+                branch.startsWith("${supportPrefix}${separator}") -> {
+                    rv = versionFromSupport( false)
+                }
                 else -> {
                     val branches = getBranchListForRef()
                     rv = when {


### PR DESCRIPTION
A new condition has been added in the GitVersionService file to check for branches that start with the "support" prefix. These branches will now use the versionFromSupport function to determine their version.