### PR TITLE
fix: Refactor version metadata assignment and add new GitCreator tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ plugins {
 // release configuration
 group = "com.intershop.gradle.version"
 description = "Gradle SCM version plugin - SCM based version handling for Gradle"
-version = "1.10.2"
+version = "1.10.3"
 
 
 val sonatypeUsername: String by project

--- a/src/main/kotlin/com/intershop/gradle/gitflow/utils/GitVersionService.kt
+++ b/src/main/kotlin/com/intershop/gradle/gitflow/utils/GitVersionService.kt
@@ -285,45 +285,43 @@ class GitVersionService @JvmOverloads constructor(
     private fun versionFromRelease(isContainer: Boolean) : String {
         // version = 'branchname'-SNAPSHOT or increased version from tag ...
         val vb = getLatestVersion()
+        val addMetaData = versionForLocalChanges("", "local")
+
         return if (vb == defaultVersion) {
             val branchName = getBranchNameForVersion(releasePrefix, branch)
-            val vrb = Version.forString(branchName, versionType)
-            val v = versionForLocalChanges("${vrb}", "${vrb}-local")
-            if(isContainer) { "${ v }-latest" } else { "${ v }-SNAPSHOT" }
+            var vrb = Version.forString(branchName, versionType)
+            setMetaData(vrb, isContainer, addMetaData).toString()
         } else {
-            val addMetaData = versionForLocalChanges("", "local")
-            if (addMetaData.isNotBlank()) {
-                if(isContainer) {
-                    vb.setBranchMetadata("${addMetaData}-latest").toString()
-                } else {
-                    vb.setBranchMetadata("${addMetaData}-SNAPSHOT").toString()
-                }
-            } else {
-                vb.toString()
-            }
+            setMetaData(vb, isContainer, addMetaData).toString()
         }
     }
 
     private fun versionFromSupport(isContainer: Boolean) : String {
         // version = 'branchname'-SNAPSHOT or increased version from tag ...
         val vb = getLatestVersion()
+        val addMetaData = versionForLocalChanges("", "local")
+
         return if (vb == defaultVersion) {
             val branchName = getBranchNameForVersion(supportPrefix, branch)
-            val vrb = Version.forString(branchName, versionType)
-            val v = versionForLocalChanges("${vrb}", "${vrb}-local")
-            if(isContainer) { "${ v }-latest" } else { "${ v }-SNAPSHOT" }
+            var vrb = Version.forString(branchName, versionType)
+            setMetaData(vrb, isContainer, addMetaData).toString()
         } else {
-            val addMetaData = versionForLocalChanges("", "local")
-            if (addMetaData.isNotBlank()) {
-                if(isContainer) {
-                    vb.setBranchMetadata("${addMetaData}-latest").toString()
-                } else {
-                    vb.setBranchMetadata("${addMetaData}-SNAPSHOT").toString()
-                }
-            } else {
-                vb.toString()
-            }
+            setMetaData(vb, isContainer, addMetaData).toString()
         }
+    }
+
+    private fun setMetaData(v: Version, isContainer: Boolean, branchMetaData: String): Version {
+        var rv = if (branchMetaData.isNotBlank()) {
+            v.setBranchMetadata(branchMetaData)
+        } else {
+            v
+        }
+        rv = if(isContainer) {
+            rv.setBuildMetadata("latest")
+        } else {
+            rv.setBuildMetadata("SNAPSHOT")
+        }
+        return rv
     }
 
     /**
@@ -480,6 +478,7 @@ class GitVersionService @JvmOverloads constructor(
                     }
                 }
             }
+
         } else {
             rv = "LOCAL"
         }

--- a/src/test/groovy/com/intershop/gradle/gitflow/GitIntegrationThreeNumbersWithMetaDataSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/gitflow/GitIntegrationThreeNumbersWithMetaDataSpec.groovy
@@ -1,0 +1,1027 @@
+/*
+ * Copyright 2020 Intershop Communications AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.intershop.gradle.gitflow
+
+import com.intershop.gradle.gitflow.utils.GitCreatorThreeNumbers
+import com.intershop.gradle.gitflow.utils.GitCreatorThreeNumbersWithMetaData
+import com.intershop.gradle.gitflow.utils.GitVersionService
+import com.intershop.gradle.gitflow.utils.TestRepoCreator
+import com.intershop.gradle.test.AbstractIntegrationGroovySpec
+import com.intershop.release.version.VersionType
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class GitIntegrationThreeNumbersWithMetaDataSpec extends AbstractIntegrationGroovySpec {
+
+    def getConfGitVersionService(File dir) {
+        GitVersionService gvs = new GitVersionService(dir, VersionType.threeDigits)
+        gvs.fullbranch = true
+        return gvs
+    }
+
+    def 'test init - no releases available'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initGitRepo(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 1.0.0-SNAPSHOT (default version)'
+        version == "1.0.0-SNAPSHOT"
+        println(" - master -> 1.0.0-SNAPSHOT")
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on hotfix branch hotfix/JIRA-1'
+        creator.setBranch("hotfix/JIRA-1")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is hotfix-<branch name>'
+        version == "JIRA-1-SNAPSHOT"
+        println(" - hotfix/JIRA-1 -> JIRA-1-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-2'
+        creator.setBranch("feature/JIRA-2")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-2-SNAPSHOT"
+        println(" - feature/JIRA-2 -> JIRA-2-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 01 - no release - hotfix 1 merge'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest1(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 1.0.0-SNAPSHOT (default version)'
+        version == "1.0.0-SNAPSHOT"
+        println(' - master -> 1.0.0-SNAPSHOT')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(' - develop -> dev-SNAPSHOT')
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-2'
+        creator.setBranch("feature/JIRA-2")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-2-SNAPSHOT"
+        println(" - feature/JIRA-2 -> JIRA-2-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 03 - no release - release  branch with hotfix'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest2(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 1.0.0-SNAPSHOT (default version)'
+        version == "1.0.0-SNAPSHOT"
+        println(' - master -> 1.0.0-SNAPSHOT')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.0'
+        creator.setBranch("release/11.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.0.0-SNAPSHOT'
+        version == "11.0.0-SNAPSHOT"
+        println(" - release/11.0 -> 11.0.0-SNAPSHOT")
+        preVersion == null
+        println(' - release -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 04 - no release - release  branch merged hotfix'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest3(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 1.0.0-SNAPSHOT (default version)'
+        version == "1.0.0-SNAPSHOT"
+        println(' - master -> 1.0.0-SNAPSHOT')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.0'
+        creator.setBranch("release/11.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.0.0-SNAPSHOT'
+        version == "11.0.0-SNAPSHOT"
+        println(" - release/11.0 -> 11.0.0-SNAPSHOT")
+        preVersion == null
+        println(' - release -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on hotfix branch hotfix/JIRA-4'
+        creator.setBranch("hotfix/JIRA-4")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then:
+        version == "JIRA-4-SNAPSHOT"
+        println(" - hotfix/JIRA-4 -> JIRA-4-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+    }
+
+    def 'test 04 - release - release branch ready'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest4(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 1.0.0-SNAPSHOT (default version)'
+        version == "1.0.0-SNAPSHOT"
+        println(' - master -> 11.0.0-SNAPSHOT')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.0'
+        creator.setBranch("release/11.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.0.0-SNAPSHOT'
+        version == "11.0.0-SNAPSHOT"
+        println(" - release/11.0 -> 11.0.0-SNAPSHOT")
+        preVersion == null
+        println(' - release -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 06 - release - release branch merged and taged, release branch still available'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest5(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.0'
+        version == "11.0.0-LTS"
+        println(' - master -> 11.0.0-LTS')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.0'
+        creator.setBranch("release/11.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.0.0-SNAPSHOT'
+        version == "11.0.0-SNAPSHOT"
+        println(" - release/11.0 -> 11.0.0-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 07 - release and feature, release branch removed'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest6(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.0'
+        version == "11.0.0-LTS"
+        println(' - master -> 11.0.0-LTS')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 07 - release, hotfix and feature'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest7(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.0-LTS'
+        version == "11.0.0-LTS"
+        println(' - master -> 11.0.0-LTS')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on feature branch hotfix/JIRA-6'
+        creator.setBranch("hotfix/JIRA-6")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is hotfix-<branch name>'
+        version == "JIRA-6-SNAPSHOT"
+        println(" - hotfix/JIRA-6 -> JIRA-6-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-3'
+        creator.setBranch("feature/JIRA-3")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-3-SNAPSHOT"
+        println(" - feature/JIRA-3 -> JIRA-3-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 08 - release, feature merged'(){
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest8(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.0-LTS'
+        version == "11.0.0-LTS"
+        println(' - master -> 11.0.0-LTS')
+        preVersion == null
+        println(' - master -> pre version is null')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.1'
+        creator.setBranch("release/11.1")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.1.0-SNAPSHOT'
+        version == "11.1.0-SNAPSHOT"
+        println(" - release/11.1 -> 11.1.0-SNAPSHOT")
+        preVersion == null
+        println(' - release -> pre version is null')
+
+        when: 'on feature branch hotfix/JIRA-6'
+        creator.setBranch("hotfix/JIRA-6")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is hotfix-<branch name>'
+        version == "JIRA-6-SNAPSHOT"
+        println(" - hotfix/JIRA-6 -> JIRA-6-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 09 - releases, release branch and feature'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest9(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.1-LTS'
+        version == "11.0.1-LTS"
+        println(' - master -> 11.0.1-LTS')
+        preVersion == "11.0.0-LTS"
+        println(' - master -> pre version is 11.0.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.1'
+        creator.setBranch("release/11.1")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.1.0-SNAPSHOT'
+        version == "11.1.0-SNAPSHOT"
+        println(" - release/11.1 -> 11.1.0-SNAPSHOT")
+        preVersion == null
+        println(' - release -> pre version is null')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 10 - new release branch ready'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest10(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.0.1-LTS'
+        version == "11.0.1-LTS"
+        println(' - master -> 11.0.1-LTS')
+        preVersion == "11.0.0-LTS"
+        println(' - master -> pre version is 11.0.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release branch release/11.1'
+        creator.setBranch("release/11.1")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is 11.1.0-SNAPSHOT'
+        version == "11.1.0-SNAPSHOT"
+        println(" - release/11.1 -> 11.1.0-SNAPSHOT")
+        preVersion == "11.0.1-LTS"
+        println(' - release -> pre version is 1.0.1-LTS')
+
+        when: 'on feature branch feature/JIRA-5'
+        creator.setBranch("feature/JIRA-5")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is feature-<branch name>'
+        version == "JIRA-5-SNAPSHOT"
+        println(" - feature/JIRA-5 -> JIRA-5-SNAPSHOT")
+        preVersion == null
+        println(' - feature -> pre version is null')
+    }
+
+    def 'test 11 - release branch merged'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest11(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.0-SNAPSHOT'
+        version == "11.1.0-SNAPSHOT"
+        println(' - master -> 11.1.0-SNAPSHOT')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+    }
+
+    def 'test 12 - tagged und feature merged'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest12(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.0-LTS'
+        version == "11.1.0-LTS"
+        println(' - master -> 11.1.0-LTS')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+    }
+
+    def 'test 13 - two release branches'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest13(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.0-LTS'
+        version == "11.1.0-LTS"
+        println(' - master -> 11.1.0-LTS')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on support/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.0-LTS'
+        version == "11.1.0-LTS"
+        println(' - on release/11 -> 11.1.0')
+        preVersion == "11.0.1-LTS"
+        println(' - release -> pre version is 11.0.1-LTS')
+
+        when: 'on release/12.0'
+        creator.setBranch("release/12.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 12.0.0-SNAPSHOT'
+        version == "12.0.0-SNAPSHOT"
+        println(' - release -> 12.0.0-SNAPSHOT')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1-LTS')
+    }
+
+    def 'test 14 - two release branches and one hotfix branch'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest14(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.0-LTS'
+        version == "11.1.0-LTS"
+        println(' - master -> 11.1.0-LTS')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on release/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.1-LTS-SNAPSHOT'
+        version == "11.1.1-LTS-SNAPSHOT"
+        println(' - on release/11 -> 11.1.1-SNAPSHOT')
+        preVersion == "11.1.0-LTS"
+        println(' - release -> pre version is 11.1.0-LTS')
+
+        when: 'on release/12'
+        creator.setBranch("release/12.0")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 12.0.0-SNAPSHOT'
+        version == "12.0.0-SNAPSHOT"
+        println(' - release -> 12.0.0-SNAPSHOT')
+        preVersion == "11.0.1-LTS"
+        println(' - master -> pre version is 11.0.1')
+
+        when: 'on feature branch hotfix/JIRA-7'
+        creator.setBranch("hotfix/JIRA-7")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is hotfix-<branch name>'
+        version == "JIRA-7-SNAPSHOT"
+        println(" - hotfix/JIRA-7 -> JIRA-7-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+    }
+
+    def 'test 15 - new release branch merged'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest15(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 12.0.0-LTS'
+        version == "12.0.0-LTS"
+        println(' - master -> 12.0.0-LTS')
+        preVersion == "11.1.0-LTS"
+        println(' - master -> pre version is 11.1.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on support/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.1-LTS-SNAPSHOT'
+        version == "11.1.1-LTS-SNAPSHOT"
+        println(' - on release/11 -> 11.1.1-LTS-SNAPSHOT')
+        preVersion == "11.1.0-LTS"
+        println(' - release -> pre version is 11.1.0-LTS')
+
+        when: 'on feature branch hotfix/JIRA-7'
+        creator.setBranch("hotfix/JIRA-7")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is hotfix-<branch name>'
+        version == "JIRA-7-SNAPSHOT"
+        println(" - hotfix/JIRA-7 -> JIRA-7-SNAPSHOT")
+        preVersion == null
+        println(' - hotfix -> pre version is null')
+    }
+
+    def 'test 16 - old release taged'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest16(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 12.0.0-LTS'
+        version == "12.0.0-LTS"
+        println(' - master -> 12.0.0-LTS')
+        preVersion == "11.1.0-LTS"
+        println(' - master -> pre version is 11.1.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on support/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.1-LTS-SNAPSHOT'
+        version == "11.1.1-LTS-SNAPSHOT"
+        println(' - on release/11 -> 11.1.1-LTS-SNAPSHOT')
+        preVersion == "11.1.0-LTS"
+        println(' - release -> pre version is 11.1.0-LTS')
+    }
+
+    def 'test 17 - one master and one support branch'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest17(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then: 'Version is 12.0.1-LTS'
+        version == "12.0.0-LTS"
+        println(' - master -> 12.0.0-LTS')
+        preVersion == "11.1.0-LTS"
+        println(' - master -> pre version is 11.1.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on support/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.1'
+        version == "11.1.1-LTS"
+        println(' - on release/11 -> 11.1.1-LTS')
+        preVersion == "11.1.0-LTS"
+        println(' - release -> pre version is 11.1.0-LTS')
+    }
+
+    def 'test 18 - two "master branches" - hotfix merged in 2'() {
+        given:
+        TestRepoCreator creator = GitCreatorThreeNumbersWithMetaData.initTest18(testProjectDir, "")
+
+        when: 'on master'
+        creator.setBranch("master")
+        GitVersionService gvs = getConfGitVersionService(creator.directory)
+        String version = gvs.version
+        String preVersion = gvs.previousVersion
+
+        then:
+        version == "12.0.0-LTS"
+        println(' - master without changes')
+        preVersion == "11.1.0-LTS"
+        println(' - master -> pre version is 11.1.0-LTS')
+
+        when: 'on develop branch'
+        creator.setBranch("develop")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'version is dev-SNAPSHOT'
+        version == "dev-SNAPSHOT"
+        println(" - develop -> dev-SNAPSHOT")
+        preVersion == null
+        println(' - develop -> pre version is null')
+
+        when: 'on support/11'
+        creator.setBranch("support/11")
+        gvs = getConfGitVersionService(creator.directory)
+        version = gvs.version
+        preVersion = gvs.previousVersion
+
+        then: 'Version is 11.1.2-LTS-SNAPSHOT'
+        version == "11.1.2-LTS-SNAPSHOT"
+        println(' - support/11 -> 11.1.2-SNAPSHOT')
+        preVersion == "11.1.1-LTS"
+        println(' - release -> pre version is 11.1.1-LTS')
+    }
+}

--- a/src/test/groovy/com/intershop/gradle/gitflow/utils/GitCreatorThreeNumbersWithMetaData.groovy
+++ b/src/test/groovy/com/intershop/gradle/gitflow/utils/GitCreatorThreeNumbersWithMetaData.groovy
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2020 Intershop Communications AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intershop.gradle.gitflow.utils
+
+import org.eclipse.jgit.lib.Constants
+
+class GitCreatorThreeNumbersWithMetaData {
+
+    static TestRepoCreator initGitRepo(File dir, String buildFileContent)  {
+        TestRepoCreator creator = new TestRepoCreator(dir)
+        if(! buildFileContent.isEmpty()) {
+            //add build files
+            creator.addBuildGroovyFile(buildFileContent)
+        }
+
+        def cMaster = creator.createCommits("master", 2)
+        creator.createBranch("develop", cMaster)
+        def cDevelop = creator.createCommits("develop", 2)
+
+        creator.setBranch("master")
+        creator.createBranch("hotfix/JIRA-1", cMaster)
+        creator.createCommits("jira1", 2)
+
+        creator.setBranch("develop")
+        creator.createBranch("feature/JIRA-2", cDevelop)
+        creator.createCommits("jira2", 3)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest1(File dir, String buildFileContent) {
+        TestRepoCreator creator = initGitRepo(dir, buildFileContent)
+
+        creator.merge("master", "hotfix/JIRA-1", "feature JIRA-1 merge")
+        creator.setBranch("develop")
+        def cDevelop = creator.createCommits("develop1", 2)
+        creator.createBranch("feature/JIRA-3", cDevelop)
+        creator.createCommits("jira3", 2)
+
+        creator.merge("develop", "master", "sync after JIRA 1")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest2(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest1(dir, buildFileContent)
+
+        creator.setBranch("feature/JIRA-2")
+        creator.createCommits("jira21", 1)
+        def cFeature2 = creator.merge("develop", "feature/JIRA-2", "feature JIRA-2 merge")
+
+        creator.setBranch("develop")
+        creator.createBranch("release/11.0", cFeature2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest3(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest2(dir, buildFileContent)
+
+        creator.setBranch("develop")
+        creator.createCommits("develop2", 1)
+
+        creator.setBranch("release/11.0")
+        def cRelease = creator.createCommits("release200", 2)
+
+        creator.createBranch("hotfix/JIRA-4", cRelease)
+        creator.setBranch("hotfix/JIRA-4")
+        creator.createCommits("jira4hotfix", 2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest4(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest3(dir, buildFileContent)
+
+        creator.setBranch("develop")
+        def cDevelop2 = creator.createCommits("develop3", 1)
+        creator.createBranch("feature/JIRA-5", cDevelop2)
+        creator.setBranch("feature/JIRA-5")
+        creator.createCommits("jira5", 2)
+
+        creator.merge("release/11.0", "hotfix/JIRA-4", "merge hotfix to release 11")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest5(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest4(dir, buildFileContent)
+
+        creator.merge("develop", "release/11.0", "merge release 20 to develop")
+        def cRelease711M = creator.merge("master", "release/11.0", "merge release 11.0 to master")
+        creator.createTag("version/11.0.0-LTS", "create release tag", cRelease711M)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest6(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest5(dir, buildFileContent)
+
+        creator.removeBranch("release/11.0")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest7(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest6(dir, buildFileContent)
+
+        creator.setBranch("master")
+        creator.createBranch("hotfix/JIRA-6", Constants.HEAD)
+
+        creator.setBranch("hotfix/JIRA-6")
+        creator.createCommits("jira6", 2)
+
+        creator.setBranch("develop")
+        creator.createCommits("develop4", 2)
+        creator.setBranch("feature/JIRA-5")
+        creator.createCommits("jira51", 2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest8(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest7(dir, buildFileContent)
+
+        creator.setBranch("feature/JIRA-3")
+        creator.createCommits("jira32", 2)
+        def cFeature3 = creator.merge("develop", "feature/JIRA-3", "feature JIRA-3 merge")
+
+        creator.createBranch("release/11.1", cFeature3)
+        creator.setBranch("release/11.1")
+        creator.createCommits("release2", 1)
+
+        creator.setBranch("hotfix/JIRA-6")
+        creator.createCommits("jira61", 2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest9(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest8(dir, buildFileContent)
+
+        def cHotfix6 = creator.merge("master", "hotfix/JIRA-6",  "merge hotfix JIRA6 to master")
+        creator.merge("develop", "hotfix/JIRA-6",  "merge hotfix JIRA6 to master")
+        creator.setBranch("master")
+        creator.createTag("version/11.0.1-LTS", "create release tag", cHotfix6)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest10(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest9(dir, buildFileContent)
+
+        creator.merge("develop", "master",  "merge release 21 hotfix 6 to develop")
+        creator.merge("release/11.1", "master",  "merge release 21 hotfix 6 to develop")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest11(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest10(dir, buildFileContent)
+
+        creator.setBranch("develop")
+        creator.createCommits("develop5", 2)
+
+        creator.setBranch("release/11.1")
+        creator.createCommits("release21", 2)
+
+        creator.setBranch("develop")
+        creator.createCommits("release22", 1)
+
+        creator.merge("master", "release/11.1", "merge release 21 to master")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest12(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest11(dir, buildFileContent)
+
+        creator.merge("develop", "release/11.1",  "merge release 21 to develop")
+        creator.removeBranch("release/11.1")
+
+        creator.setBranch("master")
+        creator.createTag("version/11.1.0-LTS", "create release tag", Constants.HEAD)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest13(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest12(dir, buildFileContent)
+
+        creator.setBranch("feature/JIRA-5")
+        creator.createCommits("jira52", 2)
+        def cFeature5 = creator.merge("develop", "feature/JIRA-5",  "merge feature JIRA5 to develop")
+
+        creator.setBranch("master")
+        creator.createBranch("support/11", Constants.HEAD)
+
+        creator.setBranch("develop")
+        creator.createBranch("release/12.0", cFeature5)
+        creator.createCommits("release30", 2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest14(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest13(dir, buildFileContent)
+
+        creator.setBranch("support/11")
+        def cRelease1 = creator.createCommits("release4", 2)
+
+        creator.createBranch("hotfix/JIRA-7", cRelease1)
+        creator.setBranch("hotfix/JIRA-7")
+        creator.createCommits("jira7", 2)
+
+        creator.setBranch("release/12.0")
+        creator.createCommits("release31", 2)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest15(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest14(dir, buildFileContent)
+
+        def cRelease3 = creator.merge("master", "release/12.0", "merge release 3 to master")
+        creator.merge("develop", "release/12.0",  "merge release 3 to develop")
+
+        creator.removeBranch("release/12.0")
+
+        creator.setBranch("master")
+        creator.createTag("version/12.0.0-LTS", "create release tag", cRelease3)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest16(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest15(dir, buildFileContent)
+
+        creator.setBranch("hotfix/JIRA-7")
+        creator.createCommits("jira71", 2)
+
+        creator.merge("support/11", "hotfix/JIRA-7",  "merge hotfix to support")
+
+        return creator
+    }
+
+    static TestRepoCreator initTest17(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest16(dir, buildFileContent)
+
+        creator.setBranch("support/11")
+        def cRelease4 = creator.createCommits("release210", 1)
+        creator.createTag("version/11.1.1-LTS", "create release tag", cRelease4)
+
+        return creator
+    }
+
+    static TestRepoCreator initTest18(File dir, String buildFileContent) {
+        TestRepoCreator creator = initTest17(dir, buildFileContent)
+
+        creator.setBranch("support/11")
+        creator.createCommits("release212", 2)
+
+        return creator
+    }
+}


### PR DESCRIPTION
Refactored the way branch version metadata is assigned in GitVersionService.kt to reduce code duplication and enhance readability. In addition, new tests have been added to verify these changes using GitCreatorThreeNumbersWithMetaData.groovy.